### PR TITLE
Refs 68056 update eeasearch to use eeacms/node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM node:4.2.2
+FROM eeacms/node
 ENV NODE_ENV 'production'
 ADD ./app/package.json /tmp/package.json
 ADD ./README.md /tmp/README.md
 RUN cd /tmp && npm install && mv /tmp/node_modules /node_modules
 ADD ./app /code
-ENTRYPOINT ["/code/app.js"]
-CMD ["runserver"]
+USER node

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:4.2.2
+FROM eeacms/node
 ENV NODE_ENV 'dev'
 ADD ./app/package.json /tmp/package.json
 ADD ./README.md /tmp/README.md
@@ -7,5 +7,5 @@ RUN npm install -g nodemon
 ADD ./eea-searchserver /tmp/eea-searchserver
 RUN npm install /tmp/eea-searchserver
 ADD ./app /code
-ENTRYPOINT ["nodemon", "--watch", "code/", "/code/app.js"]
-CMD ["runserver"]
+#ENTRYPOINT ["nodemon", "--watch", "code/", "/code/app.js"]
+USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Development docker-compose file with server auto-reload and
 # code mounted as a volume.
 app:
-    image: eeacms/eeasearch:dev
+    image: eeacms/eeasearch
     ports: # App accessible on http://localhost:3000
         - 3000:3000
     volumes: # Mount code as a volume for easy restart


### PR DESCRIPTION
Refs 68056 update eea.docker.eeasearch to use eeacms/node + chaperone + user node
